### PR TITLE
Dictops

### DIFF
--- a/transcrypt/development/automated_tests/time/autotest.py
+++ b/transcrypt/development/automated_tests/time/autotest.py
@@ -1,0 +1,11 @@
+import org.transcrypt.autotester
+
+import testlet0, strptime, mult_time
+
+autoTester = org.transcrypt.autotester.AutoTester ()
+
+autoTester.run (testlet0, 'testlet0')
+autoTester.run (strptime, 'strptime')
+autoTester.run (mult_time, 'mult_time')
+
+autoTester.done ()

--- a/transcrypt/development/automated_tests/time/mult_time.py
+++ b/transcrypt/development/automated_tests/time/mult_time.py
@@ -1,0 +1,45 @@
+'''
+testing strftime.
+'''
+
+import time
+
+
+def run (autoTester):
+    t = [2000, 1, 1, 1, 1, 1, 1, 1, 0]
+    def check(fmt):
+        s = time.mktime(tuple(t))
+        autoTester.check('gmtime'   , tuple(time.gmtime(int(s))))
+        autoTester.check('localtime', tuple(time.localtime(int(s))))
+        autoTester.check('mktime'   , int(s))
+        autoTester.check('ctime'    , int(s))
+
+    for hour in (0, 1, 12, 14, 23):
+        t[3] = hour
+        for f in (
+             '%p %I.%d.%Y'
+            ,'%b .%d.%y'
+            ,'%b .%d.%Y'
+            ,'%d%m%Y%H:%M:%S%p'
+            ,'%b .%d.%Y'
+            ,'M%m.%d.%Y'
+            ,'%m.%d.%Y'
+            ,'%m.%d.%Y'
+            ,'%b .%d.%Y'
+            ,'%m.%d.%Y'
+            ,'%B %d.%Y'
+            ,'%a %b %d %H:%M:%S %Y'
+            ,'%d.%m.%Y %I:%M:%S%p'
+            ,'%a%b %d %H:%M:%S %Y'
+            ,'%a%b%d %H:%M:%S %Y'
+            ,'%a%b%d%H:%Mx%S%Y'
+            ,'%a%b%d%H:%Mxx%S%Y'
+            ,'%a%b%d%H:%Mxx%S%Y +000'
+            ,' %a%b%d%H:%Mxx%S%Y +000 '
+            ): check(f)
+
+    autoTester.check('asctime', t)
+
+
+
+

--- a/transcrypt/development/automated_tests/time/mult_time.py
+++ b/transcrypt/development/automated_tests/time/mult_time.py
@@ -8,11 +8,7 @@ import time
 def run (autoTester):
     t = [2000, 1, 1, 1, 1, 1, 1, 1, 0]
     def check(fmt):
-        s = time.mktime(tuple(t))
-        autoTester.check('gmtime'   , tuple(time.gmtime(int(s))))
-        autoTester.check('localtime', tuple(time.localtime(int(s))))
-        autoTester.check('mktime'   , int(s))
-        autoTester.check('ctime'    , int(s))
+        autoTester.check(time.strftime(fmt, tuple(t)))
 
     for hour in (0, 1, 12, 14, 23):
         t[3] = hour
@@ -37,6 +33,12 @@ def run (autoTester):
             ,'%a%b%d%H:%Mxx%S%Y +000'
             ,' %a%b%d%H:%Mxx%S%Y +000 '
             ): check(f)
+
+        s = time.mktime(tuple(t))
+        autoTester.check('gmtime'   , tuple(time.gmtime(int(s))))
+        autoTester.check('localtime', tuple(time.localtime(int(s))))
+        autoTester.check('mktime'   , int(s))
+        autoTester.check('ctime'    , int(s))
 
     autoTester.check('asctime', t)
 

--- a/transcrypt/development/automated_tests/time/strptime.py
+++ b/transcrypt/development/automated_tests/time/strptime.py
@@ -1,0 +1,47 @@
+'''
+testing strptime.
+
+Note, Py3 bug:
+
+while true; do
+    python3.5 -c "import time; print(tuple(time.strptime('nov 1.1.1900', '%b %m.%d.%Y')))"
+done
+
+=> we simply cannot test conflicting %b %m switches,
+it decides per run which one it takes(!!!), so autotest would fail randomly.
+
+Verified with 3.4, 3.5 on mac and linux.
+
+Root cause explained here: https://github.com/JdeH/Transcrypt/issues/85
+'''
+
+import time
+
+# Note: The localized names for months and weekdays assumed to be english here.
+# And the js implementation takes the names of the locale. That may fail the
+# tests in other areas of the world. tried with export LANG other locales but
+# did not get an error though.
+# In any case the Js implementation of the checking the weekdays and monthnames
+# should be safe.
+
+def run (autoTester):
+    def check(t, fmt):
+        s = tuple(time.strptime(t, fmt))
+        autoTester.check(' '.join([t, '[', fmt, '] = ']), s)
+
+    check('FEb .1.1902'               , '%b .%d.%Y')
+    check('3112199912:00:00pm'         , '%d%m%Y%H:%M:%S%p')
+    check('FEb .1.1902'               , '%b .%d.%Y')
+    check('M1.1.1901'                  , 'M%m.%d.%Y')
+    check('2.1.1900'                   , '%m.%d.%Y')
+    check('6.1.2000'                   , '%m.%d.%Y')
+    check('nov .1.1900'                , '%b .%d.%Y')
+    check('2.1.1900'                   , '%m.%d.%Y')
+    check('december 1.1999'            , '%B %d.%Y')
+    check('Tue Jul 18 19:32:11 2016'   , '%a %b %d %H:%M:%S %Y')
+    check('31.12.1999 12:00:00pm'      , '%d.%m.%Y %I:%M:%S%p')
+    check('TueJul 18 19:32:11 2016'    , '%a%b %d %H:%M:%S %Y')
+    check('TueJul18 19:32:11 2016'     , '%a%b%d %H:%M:%S %Y')
+    check('TueJul1819:32x112016'       , '%a%b%d%H:%Mx%S%Y')
+    check('TueJul1819:32xx112016'      , '%a%b%d%H:%Mxx%S%Y')
+

--- a/transcrypt/development/automated_tests/time/strptime.py
+++ b/transcrypt/development/automated_tests/time/strptime.py
@@ -1,7 +1,8 @@
 '''
 testing strptime.
 
-Note, Py3 bug:
+Note, strptime bug - not in Transcrypt but in Python, since long
+And it is biting us with py3 runtime defaults:
 
 while true; do
     python3.5 -c "import time; print(tuple(time.strptime('nov 1.1.1900', '%b %m.%d.%Y')))"
@@ -9,6 +10,7 @@ done
 
 => we simply cannot test conflicting %b %m switches,
 it decides per run which one it takes(!!!), so autotest would fail randomly.
+Obviously somebody relied on order when iterating over dicts, in the stdlib...
 
 Verified with 3.4, 3.5 on mac and linux.
 

--- a/transcrypt/development/automated_tests/time/testlet0.py
+++ b/transcrypt/development/automated_tests/time/testlet0.py
@@ -1,0 +1,19 @@
+''' general functions '''
+import time
+
+
+# accommodate the offset between python and transcrypt run:
+
+def run (autoTester):
+    c = autoTester.check
+    c('altzone:'    , time.altzone)
+    # rounding this one much, since test res is not updated when code not
+    # changes (?)
+    c('time():'     , int(time.time() / 1000))
+    c('timelen:'    , len(str(int(time.time()))))
+    # more tests in other testlests:
+    c('localtime:'  , list(time.localtime(1468968009.638596)))
+    c('gmtime:'     , list(time.gmtime(1468968009.638596)))
+    c('daylight:'  ,  bool(time.daylight))
+    c('timezone:'  ,  time.timezone)
+    c('tzname:'  ,    time.tzname)

--- a/transcrypt/development/automated_tests/transcrypt/dictionaries/__init__.py
+++ b/transcrypt/development/automated_tests/transcrypt/dictionaries/__init__.py
@@ -34,3 +34,11 @@ def run (autoTester):
 	knight = {'rudolph': 'the righteous'}
 	for k in knight:	# Autotest automatic conversion with one knight, since sort order of dict undefined
 		autoTester.check (k)
+
+	tel = {'guido': 123}
+	autoTester.check(tel.setdefault('linus', 456))
+	autoTester.check(tel.setdefault('guido', 456))
+	autoTester.check(tel.pop('guido', 1))
+	autoTester.check(tel.pop('guido', 1))
+	autoTester.check(tel.pop('foo', 'bar'))
+

--- a/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
+++ b/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
@@ -934,11 +934,20 @@ __pragma__ ('endif')
 	
 	function __setdefault__ (aKey, aDefault) {
 		var result = this [aKey];
-		return result != undefined ? 
-			result :
-			aDefault != undefined ?
-				aDefault :
-				null;
+		if (result != undefined) return result
+		var val = aDefault == undefined ? null: aDefault
+		this[aKey] = val
+		return val
+	}
+
+	function __pop__(aKey, aDefault) {
+		var result = this[aKey]
+		if (result != undefined) {
+			delete this[aKey];
+			return result
+		}
+		return aDefault
+
 	}
 	
 	function dict (objectOrPairs) {
@@ -966,6 +975,7 @@ __pragma__ ('endif')
 		Object.defineProperty (instance, 'del', {value: __del__, enumerable: false});
 		Object.defineProperty (instance, 'clear', {value: __clear__, enumerable: false});
 		Object.defineProperty (instance, 'setdefault', {value: __setdefault__, enumerable: false});
+		Object.defineProperty (instance, 'py_pop', {value: __pop__, enumerable: false});
 		
 		return instance;
 	}

--- a/transcrypt/modules/time/__init__.py
+++ b/transcrypt/modules/time/__init__.py
@@ -477,7 +477,7 @@ def strftime(format, t):
             v = 12
         elif v > 12:
             v = v - 12
-        elif v < 10:
+        if v < 10:
             v = '0' + str(v)
         f = f.replace('%I', v)
 

--- a/transcrypt/modules/time/__init__.py
+++ b/transcrypt/modules/time/__init__.py
@@ -1,0 +1,486 @@
+"""
+time module
+
+No:
+
+- Platform specific functions
+- sleep. In js currently not possible in browsers
+         except via busy loops, we don't do that.
+- struct_time CLASS. we work only via the tuple interface of it.
+- handling of weired stuff.
+    e.g.: In Europe/Simferopool (Ukraine) the UTC offset before 1924 was +2.67
+
+Spec for all below (must have open to read this module):
+
+> https://docs.python.org/3.5/library/time.html
+
+
+Jul 2016, Gunther Klessinger, Axiros GmbH
+"""
+
+# we don't need those:
+__pragma__ ('nokwargs')
+
+# for js dates:
+from org.transcrypt.stubs.browser import __new__
+
+# js date object. might be modified during calculations:
+__date = __new__(Date(0))
+__now = __new__(Date())
+
+
+# build the locale's weekday names
+__weekdays = []
+__weekdays_long = []
+__d = __new__(Date(1467662339080)) # a monday
+for i in range(7):
+    for l, s in (__weekdays, 'short'), (__weekdays_long, 'long'):
+        l.append(__d.toLocaleString(window.navigator.language,
+                                        {'weekday': s}).lower())
+    __d.setDate(__d.getDate() + 1)
+
+
+# build the locale's months names
+__months = []
+__months_long = []
+__d = __new__(Date(946681200000.0)) # 1.1.2000
+for i in range(12):
+    for l, s in ((__months, 'short'), (__months_long, 'long')):
+        l.append(__d.toLocaleString(window.navigator.language,
+                                        {'month': s}).lower())
+    __d.setMonth(__d.getMonth() + 1)
+
+
+
+# lookup for positions directives in struct_time tuples:
+# its a 9-sequence
+#        time.struct_time(tm_year=2016, tm_mon=7, tm_mday=19, tm_hour=2,
+#                         tm_min=24, tm_sec=2, tm_wday=1, tm_yday=201,
+#                         tm_isdst=1)
+__lu = {'Y': 0, 'm': 1, 'd': 2, 'H': 3, 'M': 4, 'S': 5}
+
+def _lsplit(s, sep, maxsplit):
+    """ not yet in TS """
+    if maxsplit == 0:
+        return [s]
+    split = s.split(sep)
+    if not maxsplit:
+        return split
+    ret = split.slice(0, maxsplit, 1)
+    if len(ret) == len(split):
+        return ret
+    ret.append(sep.join(split[maxsplit:]))
+    return ret
+
+
+def _local_time_tuple(jd):
+    """ jd: javascript Date object, from unixtimestamp """
+    res =  ( jd.getFullYear()
+            ,jd.getMonth() + 1 # zero based
+            ,jd.getDate()
+            ,jd.getHours()
+            ,jd.getMinutes()
+            ,jd.getSeconds()
+            ,jd.getDay() - 1
+            ,_day_of_year(jd, True)
+            ,_daylight(jd)
+            ,jd.getMilliseconds() # not in use by the pub API
+           )
+    return res
+
+def _utc_time_tuple(jd):
+    """ jd: javascript Date object, from unixtimestamp """
+    res =  ( jd.getUTCFullYear()
+            ,jd.getUTCMonth() + 1 # zero based
+            ,jd.getUTCDate()
+            ,jd.getUTCHours()
+            ,jd.getUTCMinutes()
+            ,jd.getUTCSeconds()
+            ,jd.getUTCDay() - 1
+            ,_day_of_year(jd, False)
+            ,0 # is dst for utc: 0
+            ,jd.getUTCMilliseconds()
+           )
+    return res
+
+def _day_of_year(jd, local):
+    # check if jd hours are ahead of UTC less than the offset to it:
+    day_offs = 0
+    if jd.getHours() + jd.getTimezoneOffset() * 60 / 3600 < 0:
+        day_offs = -1
+    was = jd.getTime()
+    cur = jd.setHours(23)
+    jd.setUTCDate(1)
+    jd.setUTCMonth(0)
+    jd.setUTCHours(0)
+    jd.setUTCMinutes(0)
+    jd.setUTCSeconds(0)
+    res = round((cur - jd) / 86400000 )
+    #res = round(((jd.setHours(23) - new Date(jd.getYear(), 0, 1, 0, 0, 0)
+    #                 ) / 1000 / 60 / 60 / 24))
+    if not local:
+        res += day_offs
+
+    if res == 0:
+        res = 365
+        jd.setTime(jd.getTime() - 86400)
+        last_year = jd.getUTCFullYear()
+        if _is_leap(last_year):
+            res = 366
+    jd.setTime(was)
+    return res
+
+def _is_leap(year):
+    return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
+
+def __get_jan_jun(t):
+    __jan = __new__(Date(t.getFullYear(), 0, 1))
+    __jun = __new__(Date(t.getFullYear(), 6, 1))
+    return (__jan, __jun)
+
+def _daylight(t):
+    """
+    http://stackoverflow.com/questions/11887934/
+    check-if-daylight-saving-time-is-in-effect-and-if-it-is-for-how-many-hours
+
+    return 0 or 1 like python
+    """
+    jj = __get_jan_jun(t)
+    # in southern hemisphere the daylight saving is in winter months!
+    if min(jj[0].getTimezoneOffset(),
+           jj[1].getTimezoneOffset()) == t.getTimezoneOffset():
+        return 1
+    return 0
+
+def _timezone(t):
+    jj = __get_jan_jun(t)
+    # in southern hemisphere the daylight saving is in winter months!
+    return max(jj[0].getTimezoneOffset(),
+               jj[1].getTimezoneOffset())
+
+
+def __tzn(t):
+    # depending on browser ? new Date() -> Wed Jul... (CEST)
+    try:
+        return str(t).split('(')[1].split(')')[0]
+    except:
+        # better no crash:
+        return 'n.a.'
+
+def _tzname(t):
+    cn = __tzn(t)
+    ret = [cn, cn]
+    jj = __get_jan_jun(t)
+    for i in jj:
+        r = __tzn(i)
+        if r != cn:
+            ret[0] = r
+    return tuple(ret)
+
+
+
+
+# ------------------------------------------------------------------ Public API
+
+# we calc that only once. I mean - we run in the browser in the end:
+altzone  = __now.getTimezoneOffset() * 60
+
+timezone = _timezone(__now) * 60
+
+daylight = _daylight(__now)
+
+tzname   = _tzname(__now)
+
+
+def time():
+    """
+    time() -> floating point number\n\nReturn the current time in seconds
+    since the Epoch.
+    Fractions of a second may be present if the system clock provides them.
+    """
+    return Date.now() / 1000
+
+
+def asctime(t):
+    return strftime('%a %b %d %H:%M:%S %Y', t)
+
+
+def mktime(t):
+    ''' inverse of localtime '''
+    d = __new__(Date(t[0], t[1] - 1, t[2], t[3], t[4], t[5], 0))
+    return (d - 0) / 1000
+
+
+def ctime(seconds):
+    """
+    ctime(seconds) -> string
+
+    Convert a time in seconds since the Epoch to a string in local time.
+    This is equivalent to asctime(localtime(seconds)). When the time tuple is
+    not present, current time as returned by localtime() is used.'
+    """
+    if not seconds:
+        seconds = time()
+    return asctime(localtime(seconds))
+
+
+def localtime(seconds):
+    """
+    localtime([seconds]) -> (tm_year,tm_mon,tm_mday,tm_hour,tm_min,
+                          tm_sec,tm_wday,tm_yday,tm_isdst)
+
+    Convert seconds since the Epoch to a time tuple expressing local time.
+    When 'seconds' is not passed in, convert the current time instead.
+    """
+    if not seconds:
+        seconds = time()
+    return gmtime(seconds, True)
+
+
+def gmtime(seconds, localtime):
+    """
+    localtime([seconds]) -> (tm_year,tm_mon,tm_mday,tm_hour,tm_min,
+                          tm_sec,tm_wday,tm_yday,tm_isdst)
+
+    Convert seconds since the Epoch to a time tuple expressing local time.
+    When 'seconds' is not passed in, convert the current time instead.
+    """
+    if not seconds:
+        seconds = time()
+    millis = seconds * 1000
+    __date.setTime(millis)
+    if localtime:
+        t = _local_time_tuple(__date)
+    else:
+        t = _utc_time_tuple(__date)
+    return t[:9]
+
+# ----------------------------------------------------------------------------
+# now the workhorses:
+def strptime(string, format):
+    """
+    strptime(string, format) -> struct_time
+
+    Parse a string to a time tuple according to a format specification.
+    See the library reference manual for formatting codes (same as
+            strftime()).
+
+    Commonly used format codes:
+
+        %Y  Year with century as a decimal number.
+        %m  Month as a decimal number [01,12].
+        %d  Day of the month as a decimal number [01,31].
+        %H  Hour (24-hour clock) as a decimal number [00,23].
+        %M  Minute as a decimal number [00,59].
+        %S  Second as a decimal number [00,61].
+        %z  Time zone offset from UTC.
+        %a  Locale's abbreviated weekday name.
+        %A  Locale's full weekday name.
+        %b  Locale's abbreviated month name.
+        %B  Locale's full month name.
+        %c  Locale's appropriate date and time representation.
+        %I  Hour (12-hour clock) as a decimal number [01,12].
+        %p  Locale's equivalent of either AM or PM.
+
+        Tradoffs of this Transcrypt implementation:
+
+        1. platform specific codes not supported
+        2. %% and %c not supported
+        """
+
+    if not format:
+        format = "%a %b %d %H:%M:%S %Y"
+    ts, fmt = string, format
+    def get_next(fmt):
+        ''' returns next directive, next seperator, rest of format str'''
+        def get_sep(fmt):
+            res = []
+            if not fmt:
+                return '', ''
+            for i in range(len(fmt)-1):
+                c = fmt[i]
+                if c == '%':
+                    break
+                res.append(c)
+            return ''.join(res), fmt[i:]
+
+        # return next seperator:
+        d, sep, f = None, None, None
+        if fmt:
+            if fmt[0] == '%':
+                d = fmt[1]
+                sep, f = get_sep(fmt[2:])
+            else:
+                sep, f = get_sep(fmt)
+        return d, sep, f
+
+    # directive / value tuples go in here:
+    dir_val = {}
+    while ts:
+        d, sep, fmt = get_next(fmt)
+        if sep == '':
+            lv = None
+            if d:
+                # we have a directive, seperator is empty. Is the directive
+                # fixed length, with next w/o sep? e.g. %Y%Z ?
+                # then get the next one like:
+                l = -1
+                if   d == 'Y': l = 4
+                elif d == 'a': l = len(__weekdays[0])
+                elif d == 'A': l = len(__weekdays_long[0])
+                elif d == 'b': l = len(__months[0])
+                elif d in ('d', 'm', 'H', 'M', 'S'):
+                    l = 2
+                if l > -1:
+                    lv = [ts[:l], ts[l:]]
+            if not lv:
+                lv = [ts, '']
+        else:
+            lv = _lsplit(ts, sep, 1)
+        if d == None:
+            ts = lv[1]
+            continue
+        ts, dir_val[d] = lv[1], lv[0]
+        if fmt == '':
+            break
+    # defaults when not specified:
+    t = [1900, 1, 1, 0, 0, 0, 0, 1, -1]
+    ignore_keys = []
+    have_weekday = False
+    for d, v in dir_val.items():
+        if d in ignore_keys:
+            continue
+
+        if d == 'p':
+            continue
+
+        if d in __lu.keys():
+            t[__lu[d]] = int(v)
+            continue
+
+        if d in ('a', 'A', 'b', 'B'):
+            v = v.lower()
+
+        if d == 'm':
+            # we go the python 2(!) way for conflicting %b %m and take %m
+            # why? because there IS no Py3 way (see strp time testlet)
+            ignore_keys.append('b')
+            ignore_keys.append('B')
+
+        # better readable than short:
+        if d == 'a':
+            # funny. the weekday is only set but does not override %d.
+            # -> produces impossible dates but well its how py does it:
+            if not v in __weekdays:
+                raise ValueError('Weekday unknown in your locale')
+            have_weekday = True
+            t[6] = __weekdays.index(v)
+
+        elif d == 'A':
+            # funny. the weekday is only set but does not override %d.
+            # -> produces impossible dates but well its how py does it:
+            if not v in __weekdays_long:
+                raise ValueError('Weekday unknown in your locale')
+            have_weekday = True
+            t[6] = __weekdays_long.index(v)
+
+        elif d == 'b':
+            # month short. precedence over %m
+            # funny. the weekday is only set but does not override %d.
+            # -> produces impossible dates but well its how py does it:
+            if not v in __months:
+                raise ValueError('Month unknown in your locale')
+            t[1] = __months.index(v) + 1
+
+        elif d == 'B':
+            # month short. precedence over %m
+            # funny. the weekday is only set but does not override %d.
+            # -> produces impossible dates but well its how py does it:
+            if not v in __months_long:
+                raise ValueError('Month unknown in your locale')
+            t[1] = __months_long.index(v) + 1
+
+
+        elif d == 'I':
+            # 0-12 hour, with AM/PM.
+            ampm = dir_val['p'] or 'am'
+            ampm = ampm.lower()
+            v = int(v)
+            # thats how py does it
+            if v == 12:
+                v = 0
+            elif v > 12:
+                raise ValueError("time data '" + string + \
+                        "' does not match format '" + format + "'")
+            if ampm == 'pm':
+                v += 12
+            t[__lu['H']] = v
+
+        elif d == 'y':
+            t[0] = 2000 + int(v) # producing a y3k problem. try find me, then.
+
+        elif d == 'Z':
+            if v.lower() in ['gmt', 'utc']:
+                t[-1] = 0
+
+    # get day of year, costing us an object, to stay safe:
+    __date = __new__(Date(0))
+    __date.setUTCFullYear( t[0] )
+    __date.setUTCMonth(t[1] -1 )
+    __date.setUTCDate( t[2] )
+    __date.setUTCHours(t[3])
+    t[7] = _day_of_year(__date)
+    if not have_weekday:
+        t[6] = __date.getUTCDay() -1
+
+    return t
+
+
+def strftime(format, t):
+    def zf2(v):
+        ''' zfill missing '''
+        if v < 10:
+            return '0' + str(v)
+        return v
+
+    if not t:
+        t = localtime()
+
+    f = format
+    for d in __lu.keys():
+        k = '%' + d
+        if not k in f:
+            continue
+        v = zf2(t[__lu[d]])
+        f = f.replace(k, v)
+    for d, l, pos in (('b', __months  , 1), ('B', __months_long  , 1),
+                      ('a', __weekdays, 6), ('A', __weekdays_long, 6)):
+        p = t[pos]
+        if pos == 1:
+            p = p -1
+        v = l[p].capitalize()
+        f = f.replace('%' + d, v)
+
+    if '%p' in f:
+        if t[3] > 11:
+            ap = 'PM'
+        else:
+            ap = 'AM'
+        f = f.replace('%p', ap)
+
+    if '%y' in f:
+        f = f.replace('%y', str(t[0])[-2:])
+
+    if '%I' in f:
+        v = t[3]
+        if v == 0:
+            v = 12
+        elif v > 12:
+            v = v - 12
+        elif v < 10:
+            v = '0' + str(v)
+        f = f.replace('%I', v)
+
+    return f
+
+


### PR DESCRIPTION
Hi, this one fixes and tests setdefault on dicts plus provides dictionary pop ops, they are superconvenient especially when not using kwargs (args.pop('name', 'defaultname') )

I do the function within py_pop, since the compiler creates a py_pop method on dicts, not a pop, like it was an array. I'm happy with that. 